### PR TITLE
[rpm-ostree] Add base bleeding edge build

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,6 +40,15 @@ tasks:
     cmds:
       - rpm-ostree compose image --initialize-mode=always --format=ociarchive playtron-os.yaml playtron-os-base.ociarchive
 
+  container-image:build-base-bleeding-edge:
+    desc: Build the base OCI container image using kernel-mainline and mesa-git packages.
+    dir: rpm-ostree
+    cmds:
+      - sed -i s'/enabled=0/enabled=1/'g kernel-mainline-wo-mergew.repo
+      - sed -i s'/enabled=0/enabled=1/'g mesa-git-x86_64.repo
+      - sed -i s'/enabled=0/enabled=1/'g mesa-git-i686.repo
+      - task: container-image:build-base
+
   container-image:load-base:
     desc: Load the base OCI container image.
     dir: rpm-ostree

--- a/rpm-ostree/containerfiles/unstable
+++ b/rpm-ostree/containerfiles/unstable
@@ -12,7 +12,7 @@ COPY kernel-fsync.repo /etc/yum.repos.d/
 ## RPM Fusion.
 COPY rpmfusion-free.repo rpmfusion-free-updates.repo rpmfusion-free-updates-testing.repo rpmfusion-nonfree.repo rpmfusion-nonfree-tainted.repo rpmfusion-nonfree-updates.repo rpmfusion-nonfree-updates-testing.repo /etc/yum.repos.d/
 ## Playtron.
-COPY inputplumber-x86_64.repo playtron-app-x86_64.repo playtron-gaming-i386.repo playtron-gaming-x86_64.repo /etc/yum.repos.d/
+COPY inputplumber-x86_64.repo kernel-mainline-wo-mergew.repo mesa-git-x86_64.repo mesa-git-i686.repo playtron-app-x86_64.repo playtron-gaming-i386.repo playtron-gaming-x86_64.repo /etc/yum.repos.d/
 
 # On x86, also install 32-bit Mesa.
 # Our Arm builds are only 64-bit.

--- a/rpm-ostree/kernel-mainline-wo-mergew.repo
+++ b/rpm-ostree/kernel-mainline-wo-mergew.repo
@@ -1,0 +1,10 @@
+[kernel-mainline-wo-mergew]
+name=Copr copr.fedorainfracloud.org/@kernel-vanilla/mainline runtime dependency #1 - @kernel-vanilla/mainline-wo-mergew
+baseurl=https://download.copr.fedorainfracloud.org/results/@kernel-vanilla/mainline-wo-mergew/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@kernel-vanilla/mainline-wo-mergew/pubkey.gpg
+repo_gpgcheck=0
+enabled=0
+enabled_metadata=1

--- a/rpm-ostree/mesa-git-i686.repo
+++ b/rpm-ostree/mesa-git-i686.repo
@@ -1,0 +1,8 @@
+[mesa-git-i686]
+name=Copr repo with mesa built from the official mesa git - i386
+baseurl=https://copr-be.cloud.fedoraproject.org/results/xxmitsu/mesa-git/fedora-$releasever-i386/
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/xxmitsu/mesa-git/pubkey.gpg
+enabled=0
+enabled_metadata=1

--- a/rpm-ostree/mesa-git-x86_64.repo
+++ b/rpm-ostree/mesa-git-x86_64.repo
@@ -1,0 +1,8 @@
+[mesa-git-x86_64]
+name=Copr repo with mesa built from the official mesa git - x86_64
+baseurl=https://copr-be.cloud.fedoraproject.org/results/xxmitsu/mesa-git/fedora-$releasever-$basearch/
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/xxmitsu/mesa-git/pubkey.gpg
+enabled=0
+enabled_metadata=1

--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -101,6 +101,9 @@ repos:
   - fedora-cisco-openh264
   - inputplumber-x86_64
   - kernel-fsync-x86_64
+  - kernel-mainline-wo-mergew
+  - mesa-git-x86_64
+  - mesa-git-i686
   - playtron-gaming-x86_64
   - playtron-gaming-i386
   - playtron-app-x86_64


### PR DESCRIPTION
This builds with the kernel-mainline and mesa-git packages.

The repositories for those packages are added to the normal base image but are disabled by default.