### PR TITLE
[rpm-ostree] Use local public GPG keys

### DIFF
--- a/rpm-ostree/rpmfusion-free-updates-testing.repo
+++ b/rpm-ostree/rpmfusion-free-updates-testing.repo
@@ -7,7 +7,7 @@ enabled_metadata=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-testing-debuginfo]
 name=RPM Fusion for Fedora $releasever - Free - Test Updates Debug
@@ -17,7 +17,7 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-testing-source]
 name=RPM Fusion for Fedora $releasever - Free - Test Updates Source
@@ -27,5 +27,5 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 

--- a/rpm-ostree/rpmfusion-free-updates.repo
+++ b/rpm-ostree/rpmfusion-free-updates.repo
@@ -7,7 +7,7 @@ enabled_metadata=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-debuginfo]
 name=RPM Fusion for Fedora $releasever - Free - Updates Debug
@@ -17,7 +17,7 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-source]
 name=RPM Fusion for Fedora $releasever - Free - Updates Source
@@ -27,5 +27,5 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 

--- a/rpm-ostree/rpmfusion-free.repo
+++ b/rpm-ostree/rpmfusion-free.repo
@@ -7,7 +7,7 @@ metadata_expire=14d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-debuginfo]
 name=RPM Fusion for Fedora $releasever - Free - Debug
@@ -18,7 +18,7 @@ metadata_expire=7d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-source]
 name=RPM Fusion for Fedora $releasever - Free - Source
@@ -29,5 +29,5 @@ metadata_expire=7d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 

--- a/rpm-ostree/rpmfusion-nonfree-tainted.repo
+++ b/rpm-ostree/rpmfusion-nonfree-tainted.repo
@@ -7,7 +7,7 @@ metadata_expire=14d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-tainted-debuginfo]
 name=RPM Fusion for Fedora $releasever - Nonfree tainted - Debug
@@ -18,7 +18,7 @@ metadata_expire=7d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-tainted-source]
 name=RPM Fusion for Fedora $releasever - Nonfree tainted - Source
@@ -29,5 +29,5 @@ metadata_expire=7d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 

--- a/rpm-ostree/rpmfusion-nonfree-updates-testing.repo
+++ b/rpm-ostree/rpmfusion-nonfree-updates-testing.repo
@@ -7,7 +7,7 @@ enabled_metadata=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-testing-debuginfo]
 name=RPM Fusion for Fedora $releasever - Nonfree - Test Updates Debug
@@ -17,7 +17,7 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-testing-source]
 name=RPM Fusion for Fedora $releasever - Nonfree - Test Updates Source
@@ -27,5 +27,5 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 

--- a/rpm-ostree/rpmfusion-nonfree-updates.repo
+++ b/rpm-ostree/rpmfusion-nonfree-updates.repo
@@ -7,7 +7,7 @@ enabled_metadata=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-debuginfo]
 name=RPM Fusion for Fedora $releasever - Nonfree - Updates Debug
@@ -17,7 +17,7 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-updates-source]
 name=RPM Fusion for Fedora $releasever - Nonfree - Updates Source
@@ -27,5 +27,5 @@ enabled=0
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 

--- a/rpm-ostree/rpmfusion-nonfree.repo
+++ b/rpm-ostree/rpmfusion-nonfree.repo
@@ -8,7 +8,7 @@ metadata_expire=14d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-debuginfo]
 name=RPM Fusion for Fedora $releasever - Nonfree - Debug
@@ -19,7 +19,7 @@ metadata_expire=7d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 
 [rpmfusion-nonfree-source]
 name=RPM Fusion for Fedora $releasever - Nonfree - Source
@@ -30,5 +30,5 @@ metadata_expire=7d
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=0
-gpgkey=https://playtron-dev2-global-os-public.s3.us-west-2.amazonaws.com/gpg-public-keys/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
+gpgkey=file:///usr/share/distribution-gpg-keys/rpmfusion/RPM-GPG-KEY-rpmfusion-nonfree-fedora-$releasever
 


### PR DESCRIPTION
instead of our S3 repository. These keys are installed in Fedora by default so we can simply reference those instead of maintaining and hosting them ourselves.