### PR TITLE
[kickstart] Do not enable S3 deep sleep

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg.template
+++ b/kickstart/playtron-os_kickstart.cfg.template
@@ -20,7 +20,7 @@ zerombr
 clearpart --all --initlabel --drives=vda
 # The only way to specify default kernel arguments with rpm-ostree is to specify them here in the Kickstart file.
 # https://github.com/ostreedev/ostree/issues/479#issuecomment-245266886
-bootloader --location=mbr --boot-drive=vda --append="mem_sleep_default=deep"
+bootloader --location=mbr --boot-drive=vda
 autopart --type btrfs
 
 # Setup the file system.


### PR DESCRIPTION
This causes problems on devices that do not support it. It is also being phased out and not available on the latest hardware.