### PR TITLE
OS-116 add a github actions workflow for stable builds

### DIFF
--- a/.github/workflows/container-build-stable.yaml
+++ b/.github/workflows/container-build-stable.yaml
@@ -9,7 +9,7 @@ env:
 on:
   push:
     tags:
-      - 'unstable/**'
+      - 'stable/**'
   workflow_dispatch:
     inputs:
       tag:
@@ -17,7 +17,7 @@ on:
         required: true
 
 jobs:
-  container-image:
+  container-image-stable:
     runs-on: ubuntu-latest
     steps:
       - name: Extract version
@@ -45,14 +45,8 @@ jobs:
           sudo dpkg --install task_linux_amd64.deb
           rm --force task_linux_amd64.deb
       - uses: actions/checkout@v4
-      - name: Build base container image
-        run: |
-          docker run -u root --privileged=true --rm --workdir=/srv --volume=$GITHUB_WORKSPACE:/srv quay.io/fedora-ostree-desktops/buildroot sh -c "dnf install -y go-task && go-task container-image:build-base"
-          docker rmi quay.io/fedora-ostree-desktops/buildroot
-      - name: Load base container image
-        run: task container-image:load-base
       - name: Build container image
-        run: task container-image:build
+        run: task container-image:build-stable
       - name: Authenticate to container registry
         run: task container-image:auth
       - name: Upload container image


### PR DESCRIPTION
- adds a `container-image-stable` workflow to build stable images
- stable build is triggered when a tag starting with `stable/` is pushed
- unstable build is triggered when a tag starting with `unstable/` is pushed
- both stable and unstable workflows can also be triggered manually


I considered combining the two workflows and parameterizing, but this way seemed cleaner. Combining would require conditioning several independent steps and IMO making things difficult to read/parse. The downside is the obvious duplication that we need to be aware of when making changes in the future.