### PR TITLE
[rpm-ostree] Use 'dnf5 versionlock'

### DIFF
--- a/rpm-ostree/containerfiles/stable
+++ b/rpm-ostree/containerfiles/stable
@@ -3,6 +3,9 @@ FROM registry.playtron.one/internal/playtronos:0.19.0.19
 # Set OS version
 COPY rootfs/usr/lib/os-release-playtron /usr/lib/
 
+# Prevent kernel upgrades.
+RUN dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-headers kernel-modules kernel-modules-core kernel-modules-extra
+
 # https://github.com/playtron-os/rpm-specs-gaming
 RUN dnf5 -y upgrade \
   gamescope-dbus \

--- a/rpm-ostree/containerfiles/unstable
+++ b/rpm-ostree/containerfiles/unstable
@@ -20,6 +20,9 @@ RUN cat /usr/lib/os-release
 
 ENV CMD_INSTALL="dnf5 install -y --setopt=install_weak_deps=false --setopt=max_parallel_downloads=10"
 
+# Prevent kernel upgrades.
+RUN dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-headers kernel-modules kernel-modules-core kernel-modules-extra
+
 # downgrade gamescope
 RUN wget \
   https://kojipkgs.fedoraproject.org/packages/gamescope/3.14.2/3.fc41/x86_64/gamescope-3.14.2-3.fc41.x86_64.rpm


### PR DESCRIPTION
to pin the Linux kernel version. This prevents unexpected upgrades to Linux kernel related packages.