### PR TITLE
use the latest wireplumber

### DIFF
--- a/rpm-ostree/fedora-41-updates.repo
+++ b/rpm-ostree/fedora-41-updates.repo
@@ -5,4 +5,4 @@ enabled=1
 gpgcheck=1
 metadata_expire=1d
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
-exclude=kernel* legendary mangohud wireplumber*
+exclude=kernel* legendary mangohud

--- a/rpm-ostree/fedora-41.repo
+++ b/rpm-ostree/fedora-41.repo
@@ -5,4 +5,4 @@ enabled=1
 gpgcheck=1
 metadata_expire=1d
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary
-exclude=kernel* legendary mangohud wireplumber*
+exclude=kernel* legendary mangohud


### PR DESCRIPTION
Playserve can now use the latest wireplumber so we do not have to hold back the version anymore.