### PR TITLE
Add libverified

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg.template
+++ b/kickstart/playtron-os_kickstart.cfg.template
@@ -52,9 +52,9 @@ set -e -x
 
 # Create the "playtron" user manually.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1838859
-# Put the user in the "wheel" group for elevated privileges and "input" for Autotest to work.
+# Put the user in the "wheel" group for elevated privileges, "input" for Autotest, and "tss" for Playtron Verified.
 grep -E '^input:' /usr/lib/group | tee -a /etc/group
-useradd -G wheel,input playtron
+useradd -G wheel,input,tss playtron
 echo "playtron:playtron" | chpasswd
 
 # Hide the GRUB boot menu.

--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -69,6 +69,7 @@ packages:
   - xwininfo
   - tzupdate
   - powerstation
+  - libverified
   # Input Management
   - inputplumber
   - evtest


### PR DESCRIPTION
libverified also needs the user to be in the tss group.

NOTE: this will require a re-install using a new image/installer in order for the user to be added to the group.