### PR TITLE
print nvidia build failure logs if available

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -106,6 +106,7 @@ RUN ${CMD_INSTALL} \
 
 RUN mkdir -p /run/akmods; for k in $(ls -1 /usr/src/kernels); do \
   akmods --force --kernels "${k}" --kmod "nvidia" || exit 1; \
+  ls /var/cache/akmods/nvidia/*.failed.log > /dev/null 2>&1 && cat /var/cache/akmods/nvidia/*.failed.log || true; \
   ls /usr/lib/modules/"${k}"/extra/nvidia/nvidia.ko.xz || exit 1; done; rm -r -f /run/akmods
 
 # Copy/override files


### PR DESCRIPTION
The nvidia module is failing to build on GitHub Actions (works locally). Adding this to output the contents of the log file for analysis.