### PR TITLE
disable SPDIF/IEC958 audio output so HDMI/DisplayPort is default

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -121,6 +121,9 @@ COPY rootfs/usr/share/pipewire/pipewire-pulse.conf /usr/share/pipewire/
 # Set SELinux to permissive mode
 RUN sed -i s'/SELINUX=.*/SELINUX=permissive/'g /etc/selinux/config
 
+# Disable SPDIF/IEC958 audio output
+RUN sed -e '/\[Mapping iec958/,+5 s/^/#/' -i '/usr/share/alsa-card-profile/mixer/profile-sets/default.conf'
+
 # Ensure services are enabled according to presets
 RUN systemctl preset-all
 RUN systemctl --user --global preset-all


### PR DESCRIPTION
On desktop systems there is often (always?) an SPDIF/IEC958 audio output device with no actual physical connector, but it is picked up as the default output device.

This disables that device allowing HDMI/DisplayPort to become the default, so users do not have to go into audio settings and manually adjust the audio output.